### PR TITLE
Fix logout expects refresh token

### DIFF
--- a/authentication/src/main/java/com/service/authentication/controller/AuthController.java
+++ b/authentication/src/main/java/com/service/authentication/controller/AuthController.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -67,15 +66,14 @@ public class AuthController {
     }
 
   /**
-   * Logs out the user by invalidating the refresh token associated with the provided access token.
+   * Logs out the user by invalidating the provided refresh token.
    *
-   * @param tokenHeader the authorization header containing the Bearer token
+   * @param request request containing the refresh token
    * @return a response with no content indicating successful logout
    */
   @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String tokenHeader) {
-    authService.logout(tokenHeader);
-    return ResponseEntity.ok(
-        ApiResponseUtil.success(200, "Logout successful", null));
-    }
+  public ResponseEntity<ApiResponse<Void>> logout(@RequestBody TokenRefreshRequest request) {
+    authService.logout(request.getRefreshToken());
+    return ResponseEntity.ok(ApiResponseUtil.success(200, "Logout successful", null));
+  }
 }

--- a/authentication/src/main/java/com/service/authentication/service/AuthService.java
+++ b/authentication/src/main/java/com/service/authentication/service/AuthService.java
@@ -13,5 +13,5 @@ public interface AuthService {
 
   TokenResponse refreshToken(TokenRefreshRequest request);
 
-  void logout(String accessTokenHeader);
+  void logout(String refreshToken);
 }

--- a/authentication/src/main/java/com/service/authentication/service/RefreshTokenRedisService.java
+++ b/authentication/src/main/java/com/service/authentication/service/RefreshTokenRedisService.java
@@ -7,5 +7,5 @@ public interface RefreshTokenRedisService {
 
   UUID getUserIdFromRefreshToken(String token);
 
-  boolean deleteRefreshToken(String userId);
+  boolean deleteRefreshToken(String token);
 }


### PR DESCRIPTION
## Summary
- expect refresh token for logout endpoint
- update controller and service APIs accordingly
- fix parameter name in RefreshTokenRedisService interface

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e3d8bb5f883209d8a08f90b8b5bf0